### PR TITLE
Stderr toggling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -85,7 +85,7 @@ impl Job {
 
 pub enum AppMessage {
     Jobs(Vec<Job>),
-    JobStdout(Result<String, FileWatcherError>),
+    JobOutput(Result<String, FileWatcherError>),
     Key(KeyEvent),
 }
 
@@ -156,7 +156,7 @@ impl App {
     fn handle(&mut self, msg: AppMessage) {
         match msg {
             AppMessage::Jobs(jobs) => self.jobs = jobs,
-            AppMessage::JobStdout(content) => self.job_output = content,
+            AppMessage::JobOutput(content) => self.job_output = content,
             AppMessage::Key(key) => {
                 if let Some(dialog) = &self.dialog {
                     match dialog {

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,7 +34,7 @@ pub enum ScrollAnchor {
 }
 
 #[derive(Default)]
-pub enum FileView {
+pub enum OutputFileView {
     #[default]
     Stdout,
     Stderr,
@@ -53,7 +53,7 @@ pub struct App {
     // sender: Sender<AppMessage>,
     receiver: Receiver<AppMessage>,
     input_receiver: Receiver<std::io::Result<Event>>,
-    file_view: FileView,
+    output_file_view: OutputFileView,
 }
 
 pub struct Job {
@@ -121,7 +121,7 @@ impl App {
             // sender,
             receiver: receiver,
             input_receiver: input_receiver,
-            file_view: FileView::default(),
+            output_file_view: OutputFileView::default(),
         }
     }
 }
@@ -246,9 +246,9 @@ impl App {
                             }
                         }
                         KeyCode::Char('o') => {
-                            self.file_view = match self.file_view {
-                                FileView::Stdout => FileView::Stderr,
-                                FileView::Stderr => FileView::Stdout,
+                            self.output_file_view = match self.output_file_view {
+                                OutputFileView::Stdout => OutputFileView::Stderr,
+                                OutputFileView::Stderr => OutputFileView::Stdout,
                             };
                         }
                         _ => {}
@@ -260,9 +260,9 @@ impl App {
         // update
         self.job_output_watcher
             .set_file_path(self.job_list_state.selected().and_then(|i| {
-                self.jobs.get(i).and_then(|j| match self.file_view {
-                    FileView::Stdout => j.stdout.clone(),
-                    FileView::Stderr => j.stderr.clone(),
+                self.jobs.get(i).and_then(|j| match self.output_file_view {
+                    OutputFileView::Stdout => j.stdout.clone(),
+                    OutputFileView::Stderr => j.stderr.clone(),
                 })
             }));
     }
@@ -422,17 +422,17 @@ impl App {
                 Span::raw(" "),
                 Span::raw(&j.tres),
             ]);
-            let ui_stdout_text = match self.file_view {
-                FileView::Stdout => "stdout ",
-                FileView::Stderr => "stderr ",
+            let ui_stdout_text = match self.output_file_view {
+                OutputFileView::Stdout => "stdout ",
+                OutputFileView::Stderr => "stderr ",
             };
             let stdout = Line::from(vec![
                 Span::styled(ui_stdout_text, Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
                 Span::raw(
-                    match self.file_view {
-                        FileView::Stdout => &j.stdout,
-                        FileView::Stderr => &j.stderr,
+                    match self.output_file_view {
+                        OutputFileView::Stdout => &j.stdout,
+                        OutputFileView::Stderr => &j.stderr,
                     }
                     .as_ref()
                     .map(|p| p.to_str().unwrap_or_default())
@@ -449,9 +449,9 @@ impl App {
         // Log
         let log_area = job_detail_log[1];
         let log_title = Line::from(vec![
-            Span::raw(match self.file_view {
-                FileView::Stdout => "stdout",
-                FileView::Stderr => "stderr",
+            Span::raw(match self.output_file_view {
+                OutputFileView::Stdout => "stdout",
+                OutputFileView::Stderr => "stderr",
             }),
             Span::styled(
                 match self.job_output_anchor {

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,15 +9,15 @@ use crate::file_watcher::{FileWatcherError, FileWatcherHandle};
 use crate::job_watcher::JobWatcherHandle;
 
 use crossterm::event::{Event, KeyCode, KeyEvent};
-use std::io;
 use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Span, Line, Text},
+    text::{Line, Span, Text},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame, Terminal,
 };
+use std::io;
 
 pub enum Focus {
     Jobs,
@@ -33,19 +33,27 @@ pub enum ScrollAnchor {
     Bottom,
 }
 
+#[derive(Default)]
+pub enum FileView {
+    #[default]
+    Stdout,
+    Stderr,
+}
+
 pub struct App {
     focus: Focus,
     dialog: Option<Dialog>,
     jobs: Vec<Job>,
     job_list_state: ListState,
-    job_stdout: Result<String, FileWatcherError>,
-    job_stdout_anchor: ScrollAnchor,
-    job_stdout_offset: u16,
+    job_output: Result<String, FileWatcherError>,
+    job_output_anchor: ScrollAnchor,
+    job_output_offset: u16,
     _job_watcher: JobWatcherHandle,
-    job_stdout_watcher: FileWatcherHandle,
+    job_output_watcher: FileWatcherHandle,
     // sender: Sender<AppMessage>,
     receiver: Receiver<AppMessage>,
     input_receiver: Receiver<std::io::Result<Event>>,
+    file_view: FileView,
 }
 
 pub struct Job {
@@ -62,8 +70,8 @@ pub struct Job {
     pub partition: String,
     pub nodelist: String,
     pub stdout: Option<PathBuf>,
+    pub stderr: Option<PathBuf>,
     pub command: String,
-    // pub stderr: Option<PathBuf>,
 }
 
 impl Job {
@@ -103,16 +111,17 @@ impl App {
                 s.select(Some(0));
                 s
             },
-            job_stdout: Ok("".to_string()),
-            job_stdout_anchor: ScrollAnchor::Bottom,
-            job_stdout_offset: 0,
-            job_stdout_watcher: FileWatcherHandle::new(
+            job_output: Ok("".to_string()),
+            job_output_anchor: ScrollAnchor::Bottom,
+            job_output_offset: 0,
+            job_output_watcher: FileWatcherHandle::new(
                 sender.clone(),
                 Duration::from_secs(file_refresh_rate),
             ),
             // sender,
             receiver: receiver,
             input_receiver: input_receiver,
+            file_view: FileView::default(),
         }
     }
 }
@@ -147,7 +156,7 @@ impl App {
     fn handle(&mut self, msg: AppMessage) {
         match msg {
             AppMessage::Jobs(jobs) => self.jobs = jobs,
-            AppMessage::JobStdout(content) => self.job_stdout = content,
+            AppMessage::JobStdout(content) => self.job_output = content,
             AppMessage::Key(key) => {
                 if let Some(dialog) = &self.dialog {
                     match dialog {
@@ -187,14 +196,14 @@ impl App {
                             } else {
                                 1
                             };
-                            match self.job_stdout_anchor {
+                            match self.job_output_anchor {
                                 ScrollAnchor::Top => {
-                                    self.job_stdout_offset =
-                                        self.job_stdout_offset.saturating_add(delta)
+                                    self.job_output_offset =
+                                        self.job_output_offset.saturating_add(delta)
                                 }
                                 ScrollAnchor::Bottom => {
-                                    self.job_stdout_offset =
-                                        self.job_stdout_offset.saturating_sub(delta)
+                                    self.job_output_offset =
+                                        self.job_output_offset.saturating_sub(delta)
                                 }
                             }
                         }
@@ -208,24 +217,24 @@ impl App {
                             } else {
                                 1
                             };
-                            match self.job_stdout_anchor {
+                            match self.job_output_anchor {
                                 ScrollAnchor::Top => {
-                                    self.job_stdout_offset =
-                                        self.job_stdout_offset.saturating_sub(delta)
+                                    self.job_output_offset =
+                                        self.job_output_offset.saturating_sub(delta)
                                 }
                                 ScrollAnchor::Bottom => {
-                                    self.job_stdout_offset =
-                                        self.job_stdout_offset.saturating_add(delta)
+                                    self.job_output_offset =
+                                        self.job_output_offset.saturating_add(delta)
                                 }
                             }
                         }
                         KeyCode::Home => {
-                            self.job_stdout_offset = 0;
-                            self.job_stdout_anchor = ScrollAnchor::Top;
+                            self.job_output_offset = 0;
+                            self.job_output_anchor = ScrollAnchor::Top;
                         }
                         KeyCode::End => {
-                            self.job_stdout_offset = 0;
-                            self.job_stdout_anchor = ScrollAnchor::Bottom;
+                            self.job_output_offset = 0;
+                            self.job_output_anchor = ScrollAnchor::Bottom;
                         }
                         KeyCode::Char('c') => {
                             if let Some(id) = self
@@ -236,6 +245,12 @@ impl App {
                                 self.dialog = Some(Dialog::ConfirmCancelJob(id));
                             }
                         }
+                        KeyCode::Char('o') => {
+                            self.file_view = match self.file_view {
+                                FileView::Stdout => FileView::Stderr,
+                                FileView::Stderr => FileView::Stdout,
+                            };
+                        }
                         _ => {}
                     };
                 }
@@ -243,11 +258,13 @@ impl App {
         }
 
         // update
-        self.job_stdout_watcher.set_file_path(
-            self.job_list_state
-                .selected()
-                .and_then(|i| self.jobs.get(i).and_then(|j| j.stdout.clone())),
-        );
+        self.job_output_watcher
+            .set_file_path(self.job_list_state.selected().and_then(|i| {
+                self.jobs.get(i).and_then(|j| match self.file_view {
+                    FileView::Stdout => j.stdout.clone(),
+                    FileView::Stderr => j.stderr.clone(),
+                })
+            }));
     }
 
     fn ui<B: Backend>(&mut self, f: &mut Frame<B>) {
@@ -292,6 +309,12 @@ impl App {
             Span::raw(" | "),
             Span::styled("c", Style::default().fg(Color::Blue)),
             Span::styled(": cancel job", Style::default().fg(Color::LightBlue)),
+            Span::raw(" | "),
+            Span::styled("o", Style::default().fg(Color::Blue)),
+            Span::styled(
+                ": toggle stdout/stderr",
+                Style::default().fg(Color::LightBlue),
+            ),
         ]);
         let help = Paragraph::new(help);
         f.render_widget(help, content_help[1]);
@@ -403,14 +426,21 @@ impl App {
                 Span::raw(" "),
                 Span::raw(&j.tres),
             ]);
+            let ui_stdout_text = match self.file_view {
+                FileView::Stdout => "stdout ",
+                FileView::Stderr => "stderr ",
+            };
             let stdout = Line::from(vec![
-                Span::styled("stdout ", Style::default().fg(Color::Yellow)),
+                Span::styled(ui_stdout_text, Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
                 Span::raw(
-                    j.stdout
-                        .as_ref()
-                        .map(|p| p.to_str().unwrap_or_default())
-                        .unwrap_or_default(),
+                    match self.file_view {
+                        FileView::Stdout => &j.stdout,
+                        FileView::Stderr => &j.stderr,
+                    }
+                    .as_ref()
+                    .map(|p| p.to_str().unwrap_or_default())
+                    .unwrap_or_default(),
                 ),
             ]);
 
@@ -423,13 +453,16 @@ impl App {
         // Log
         let log_area = job_detail_log[1];
         let log_title = Line::from(vec![
-            Span::raw("stdout"),
+            Span::raw(match self.file_view {
+                FileView::Stdout => "stdout",
+                FileView::Stderr => "stderr",
+            }),
             Span::styled(
-                match self.job_stdout_anchor {
-                    ScrollAnchor::Top if self.job_stdout_offset == 0 => "[T]".to_string(),
-                    ScrollAnchor::Top => format!("[T+{}]", self.job_stdout_offset),
-                    ScrollAnchor::Bottom if self.job_stdout_offset == 0 => "".to_string(),
-                    ScrollAnchor::Bottom => format!("[B-{}]", self.job_stdout_offset),
+                match self.job_output_anchor {
+                    ScrollAnchor::Top if self.job_output_offset == 0 => "[T]".to_string(),
+                    ScrollAnchor::Top => format!("[T+{}]", self.job_output_offset),
+                    ScrollAnchor::Bottom if self.job_output_offset == 0 => "".to_string(),
+                    ScrollAnchor::Bottom => format!("[B-{}]", self.job_output_offset),
                 },
                 Style::default().add_modifier(Modifier::DIM),
             ),
@@ -448,13 +481,13 @@ impl App {
         //     "".to_string()
         // });
 
-        let log = match self.job_stdout.as_deref() {
+        let log = match self.job_output.as_deref() {
             Ok(s) => Paragraph::new(string_for_paragraph(
                 s,
                 log_block.inner(log_area).height as usize,
                 log_block.inner(log_area).width as usize,
-                self.job_stdout_anchor,
-                self.job_stdout_offset as usize,
+                self.job_output_anchor,
+                self.job_output_offset as usize,
             )),
             Err(e) => Paragraph::new(e.to_string())
                 .style(Style::default().fg(Color::Red))

--- a/src/app.rs
+++ b/src/app.rs
@@ -286,36 +286,32 @@ impl App {
             .split(master_detail[1]);
 
         // Help
+        let help_options = vec![
+            ("q", "quit"),
+            ("⏶/⏷", "navigate"),
+            ("pgup/pgdown", "scroll"),
+            ("home/end", "top/bottom"),
+            ("esc", "cancel"),
+            ("enter", "confirm"),
+            ("c", "cancel job"),
+            ("o", "toggle stdout/stderr"),
+        ];
+        let blue_style = Style::default().fg(Color::Blue);
+        let light_blue_style = Style::default().fg(Color::LightBlue);
 
-        let help = Line::from(vec![
-            // ⏴⏵⏶⏷
-            Span::styled("q", Style::default().fg(Color::Blue)),
-            Span::styled(": quit", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("⏶/⏷", Style::default().fg(Color::Blue)),
-            Span::styled(": navigate", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("pgup/pgdown", Style::default().fg(Color::Blue)),
-            Span::styled(": scroll", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("home/end", Style::default().fg(Color::Blue)),
-            Span::styled(": top/bottom", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("esc", Style::default().fg(Color::Blue)),
-            Span::styled(": cancel", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("enter", Style::default().fg(Color::Blue)),
-            Span::styled(": confirm", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("c", Style::default().fg(Color::Blue)),
-            Span::styled(": cancel job", Style::default().fg(Color::LightBlue)),
-            Span::raw(" | "),
-            Span::styled("o", Style::default().fg(Color::Blue)),
-            Span::styled(
-                ": toggle stdout/stderr",
-                Style::default().fg(Color::LightBlue),
-            ),
-        ]);
+        let help = Line::from(help_options.iter().fold(
+            Vec::new(),
+            |mut acc, (key, description)| {
+                if !acc.is_empty() {
+                    acc.push(Span::raw(" | "));
+                }
+                acc.push(Span::styled(*key, blue_style));
+                acc.push(Span::raw(": "));
+                acc.push(Span::styled(*description, light_blue_style));
+                acc
+            },
+        ));
+
         let help = Paragraph::new(help);
         f.render_widget(help, content_help[1]);
 

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -103,7 +103,7 @@ impl FileWatcher {
                                         let i = self.interval.clone();
                                         thread::spawn(move || FileReader::new(_content_sender, _watch_receiver, p, i).run());
                                     },
-                                    Err(e) => self.app.send(AppMessage::JobStdout(Err(FileWatcherError::Watcher(e)))).unwrap()
+                                    Err(e) => self.app.send(AppMessage::JobOutput(Err(FileWatcherError::Watcher(e)))).unwrap()
                                 };
                             } else {
                                 _content_sender.send(Ok("".to_string())).unwrap();
@@ -113,7 +113,7 @@ impl FileWatcher {
                 }
                 recv(watch_receiver) -> _ => { _watch_sender.send(()).unwrap(); }
                 recv(_content_receiver) -> msg => {
-                    self.app.send(AppMessage::JobStdout(msg.unwrap().map_err(|e| FileWatcherError::File(e)))).unwrap();
+                    self.app.send(AppMessage::JobOutput(msg.unwrap().map_err(|e| FileWatcherError::File(e)))).unwrap();
                 }
             }
         }

--- a/src/job_watcher.rs
+++ b/src/job_watcher.rs
@@ -36,6 +36,7 @@ impl JobWatcher {
             "partition",
             "nodelist",
             "stdout",
+            "stderr",
             "command",
             "statecompact",
             "reason",
@@ -76,14 +77,15 @@ impl JobWatcher {
                     let partition = parts[6];
                     let nodelist = parts[7];
                     let stdout = parts[8];
-                    let command = parts[9];
-                    let state_compact = parts[10];
-                    let reason = parts[11];
+                    let stderr = parts[9];
+                    let command = parts[10];
+                    let state_compact = parts[11];
+                    let reason = parts[12];
 
-                    let array_job_id = parts[12];
-                    let array_task_id = parts[13];
-                    let node_list = parts[14];
-                    let working_dir = parts[15];
+                    let array_job_id = parts[13];
+                    let array_task_id = parts[14];
+                    let node_list = parts[15];
+                    let working_dir = parts[16];
 
                     Some(Job {
                         job_id: id.to_owned(),
@@ -108,6 +110,16 @@ impl JobWatcher {
                         command: command.to_owned(),
                         stdout: Self::resolve_path(
                             stdout,
+                            array_job_id,
+                            array_task_id,
+                            id,
+                            node_list,
+                            user,
+                            name,
+                            working_dir,
+                        ),
+                        stderr: Self::resolve_path(
+                            stderr,
                             array_job_id,
                             array_task_id,
                             id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,12 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use squeue_args::SqueueArgs;
-use std::{io, thread};
 use ratatui::{
     backend::{Backend, CrosstermBackend},
     Terminal,
 };
+use squeue_args::SqueueArgs;
+use std::{io, thread};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]


### PR DESCRIPTION
- Modified `App` to accept an Enum `FileView` which specifies stdout or stderr for the `App`
- Job watcher selects which path to read based on `FileView`
- UI elements also toggle between stdout/stderr
- Enum is toggled using `o` key (for output)
- stderr added to `squeue_args` in `JobWatcher`
- Streamlined generation of help to make it easier to add new elements