### PR TITLE
add verbosity on cancel

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ pub enum Focus {
 
 pub enum Dialog {
     ConfirmCancelJob(String),
+    CancelJobError(String),
 }
 
 #[derive(Clone, Copy)]
@@ -165,18 +166,31 @@ impl App {
                     match dialog {
                         Dialog::ConfirmCancelJob(id) => match key.code {
                             KeyCode::Enter | KeyCode::Char('y') => {
-                                Command::new("scancel")
+                                let output = Command::new("scancel")
                                     .arg(id)
                                     .stdout(Stdio::null())
-                                    .stderr(Stdio::null())
+                                    .stderr(Stdio::piped())
                                     .spawn()
+                                    .expect("failed to execute scancel")
+                                    .wait_with_output()
                                     .expect("failed to execute scancel");
-                                self.dialog = None;
+                                // check for error
+                                if output.status.success() {
+                                    self.dialog = None;
+                                } else {
+                                    let err_string = String::from_utf8_lossy(&output.stderr).to_string();
+                                    self.dialog = Some(Dialog::CancelJobError(
+                                        err_string
+                                       ));
+                                };
                             }
                             KeyCode::Esc => {
                                 self.dialog = None;
                             }
                             _ => {}
+                        },
+                        Dialog::CancelJobError(_error) => {
+                            self.dialog = None;
                         },
                     };
                 } else {
@@ -538,7 +552,25 @@ impl App {
                     let area = centered_lines(75, 3, f.size());
                     f.render_widget(Clear, area);
                     f.render_widget(dialog, area);
+                },
+                Dialog::CancelJobError(error) => {
+                    let dialog = Paragraph::new(Line::from(vec![
+                        Span::styled(error, Style::default().add_modifier(Modifier::BOLD)),
+                    ]))
+                    .style(Style::default().fg(Color::White))
+                    .wrap(Wrap { trim: true })
+                    .block(
+                        Block::default()
+                            .title("Error")
+                            .borders(Borders::ALL)
+                            .style(Style::default().fg(Color::Red)),
+                    );
+
+                    let area = centered_lines(75, 3, f.size());
+                    f.render_widget(Clear, area);
+                    f.render_widget(dialog, area);
                 }
+                
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -553,6 +553,7 @@ impl App {
                     f.render_widget(Clear, area);
                     f.render_widget(dialog, area);
                 },
+                // TODO: We should be able to remove this repeated code
                 Dialog::CancelJobError(error) => {
                     let dialog = Paragraph::new(Line::from(vec![
                         Span::styled(error, Style::default().add_modifier(Modifier::BOLD)),


### PR DESCRIPTION
This PR introduces a small error dialouge when users try to cancel another users job. Seems pointless, but previously when trying to cancel another user's job, there would not be any verbosity. Could be a small reminder if the user unintentionally selected the wrong job to cancel. 

<img width="409" alt="image" src="https://github.com/user-attachments/assets/13cf3f8b-637a-4699-9067-e3d2bbad79a5" />

There should be a cleaner way to write the `Dialog` since there is some repeated code. 