### PR TITLE
feat: Add Job Name to detail window

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -333,7 +333,7 @@ impl App {
 
         let job_detail_log = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(7), Constraint::Min(3)].as_ref())
+            .constraints([Constraint::Length(8), Constraint::Min(3)].as_ref())
             .split(master_detail[1]);
 
         // Help
@@ -464,9 +464,7 @@ impl App {
                     Span::raw(s),
                 ]);
             }
-
             let state = Line::from(state_spans);
-
             let name = Line::from(vec![
                 Span::styled("Name   ", Style::default().fg(Color::Yellow)),
                 Span::raw(" "),


### PR DESCRIPTION
# Description

This PR add the job name to the detail window of the turm interface to provide a way to check the name of long jobs in case they don't fit in the default window (which is often the case on my end)

Before:
<img width="398" height="63" alt="turm_before" src="https://github.com/user-attachments/assets/42707675-cbee-496d-8a69-88a0cbfd88a2" />

After:
<img width="398" height="81" alt="turm_after" src="https://github.com/user-attachments/assets/558c7ded-68b5-4298-834f-5bfe1387e1c4" />

Thanks a lot for this little TUI
