### PR TITLE
feat: Add option to run turm against remote ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,32 @@ turm completion fish | source
 
 ## How it works
 
-`turm` obtains information about jobs by parsing the output of `squeue`.
+`turm` obtains information about jobs by parsing the output of `squeue`. This can be done either locally or on a remote machine via SSH (see `--remote` and `--ssh-options`).
 The reason for this is that `squeue` is available on all Slurm clusters, and running it periodically is not too expensive for the Slurm controller ( particularly when [filtering by user](https://slurm.schedmd.com/squeue.html#OPT_user)).
 In contrast, Slurm's C API is unstable, and Slurm's REST API is not always available and can be costly for the Slurm controller.
 Another advantage is that we get free support for the exact same CLI flags as `squeue`, which users are already familiar with, for filtering and sorting the jobs.
 
-### Ressource usage
+## Remote SSH
+
+`turm` can be used to manage a remote Slurm cluster via SSH. This is useful when `turm` is not installed on the cluster, or when you want to manage multiple clusters from a single machine.
+
+To use this feature, you need to specify the remote host using the `--remote` command-line option. For example:
+
+```shell
+turm --remote user@my-cluster
+```
+
+You can also specify additional SSH options using the `--ssh-options` command-line option. For example, to use a specific identity file, you can do:
+
+```shell
+turm --remote user@my-cluster --ssh-options "-i ~/.ssh/my-key"
+```
+
+When using the remote SSH feature, `turm` will execute all Slurm commands on the remote host. It will also read the job output files from the remote host.
+
+**Note:** When using the remote SSH feature, it is recommended to set up SSH key-based authentication to avoid having to enter your password every time a command is executed.
+
+### Resource usage
 
 TL;DR: `turm` ≈ `watch -n2 squeue` + `tail -f slurm-log.out`
 

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -3,6 +3,7 @@ use std::{
     fs::File,
     io::{self, Read, Seek},
     path::{Path, PathBuf},
+    process::Command,
     thread,
     time::Duration,
 };
@@ -14,6 +15,75 @@ use crossbeam::{
 use notify::{event::ModifyKind, RecursiveMode, Watcher};
 
 use crate::app::AppMessage;
+
+struct RemoteFileReader {
+    content_sender: Sender<io::Result<String>>,
+    receiver: Receiver<()>,
+    file_path: PathBuf,
+    interval: Duration,
+    remote: String,
+    ssh_options: Option<String>,
+}
+
+impl RemoteFileReader {
+    fn new(
+        content_sender: Sender<io::Result<String>>,
+        receiver: Receiver<()>,
+        file_path: PathBuf,
+        interval: Duration,
+        remote: String,
+        ssh_options: Option<String>,
+    ) -> Self {
+        RemoteFileReader {
+            content_sender,
+            receiver,
+            file_path,
+            interval,
+            remote,
+            ssh_options,
+        }
+    }
+
+    fn run(&mut self) -> Result<(), ()> {
+        loop {
+            self.update().map_err(|_| ())?;
+            select! {
+                recv(self.receiver) -> msg => {
+                    msg.map_err(|_| ())?;
+                }
+                default(self.interval) => {}
+            }
+        }
+    }
+
+    fn update(&mut self) -> Result<(), SendError<io::Result<String>>> {
+        let mut ssh_args = Vec::new();
+        if let Some(ssh_options) = &self.ssh_options {
+            ssh_args.extend(ssh_options.split_whitespace());
+        }
+        ssh_args.push(&self.remote);
+        ssh_args.push("cat");
+        ssh_args.push(self.file_path.to_str().unwrap());
+
+        let mut cmd = Command::new("ssh");
+        cmd.args(ssh_args);
+
+        let output = cmd.output();
+
+        let s = output.and_then(|o| {
+            if o.status.success() {
+                Ok(String::from_utf8_lossy(&o.stdout).to_string())
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    String::from_utf8_lossy(&o.stderr).to_string(),
+                ))
+            }
+        });
+
+        self.content_sender.send(s)
+    }
+}
 
 struct FileReader {
     content_sender: Sender<io::Result<String>>,
@@ -29,6 +99,8 @@ struct FileWatcher {
     receiver: Receiver<FileWatcherMessage>,
     file_path: Option<PathBuf>,
     interval: Duration,
+    remote: Option<String>,
+    ssh_options: Option<String>,
 }
 pub enum FileWatcherMessage {
     FilePath(Option<PathBuf>),
@@ -58,12 +130,16 @@ impl FileWatcher {
         app: Sender<AppMessage>,
         receiver: Receiver<FileWatcherMessage>,
         interval: Duration,
+        remote: Option<String>,
+        ssh_options: Option<String>,
     ) -> Self {
         FileWatcher {
             app: app,
             receiver: receiver,
             file_path: None,
             interval: interval,
+            remote,
+            ssh_options,
         }
     }
 
@@ -91,20 +167,28 @@ impl FileWatcher {
                             (_watch_sender, _watch_receiver) = unbounded::<()>();
 
                             if let Some(p) = &self.file_path {
-                                watcher.unwatch(p).expect(format!("Failed to unwatch {:?}", p).as_str());
+                                if self.remote.is_none() {
+                                    watcher.unwatch(p).expect(format!("Failed to unwatch {:?}", p).as_str());
+                                }
                                 self.file_path = None;
                             }
 
                             if let Some(p) = file_path {
-                                let res = watcher.watch(Path::new(&p), RecursiveMode::NonRecursive);
-                                match res {
-                                    Ok(_) => {
-                                        self.file_path = Some(p.clone());
-                                        let i = self.interval.clone();
-                                        thread::spawn(move || FileReader::new(_content_sender, _watch_receiver, p, i).run());
-                                    },
-                                    Err(e) => self.app.send(AppMessage::JobOutput(Err(FileWatcherError::Watcher(e)))).unwrap()
-                                };
+                                if let Some(remote) = self.remote.clone() {
+                                    let i = self.interval.clone();
+                                    let ssh_options = self.ssh_options.clone();
+                                    thread::spawn(move || RemoteFileReader::new(_content_sender, _watch_receiver, p, i, remote, ssh_options).run());
+                                } else {
+                                    let res = watcher.watch(Path::new(&p), RecursiveMode::NonRecursive);
+                                    match res {
+                                        Ok(_) => {
+                                            self.file_path = Some(p.clone());
+                                            let i = self.interval.clone();
+                                            thread::spawn(move || FileReader::new(_content_sender, _watch_receiver, p, i).run());
+                                        },
+                                        Err(e) => self.app.send(AppMessage::JobOutput(Err(FileWatcherError::Watcher(e)))).unwrap()
+                                    };
+                                }
                             } else {
                                 _content_sender.send(Ok("".to_string())).unwrap();
                             }
@@ -163,9 +247,14 @@ impl FileReader {
 }
 
 impl FileWatcherHandle {
-    pub fn new(app: Sender<AppMessage>, interval: Duration) -> Self {
+    pub fn new(
+        app: Sender<AppMessage>,
+        interval: Duration,
+        remote: Option<String>,
+        ssh_options: Option<String>,
+    ) -> Self {
         let (sender, receiver) = unbounded();
-        let mut actor = FileWatcher::new(app, receiver, interval);
+        let mut actor = FileWatcher::new(app, receiver, interval, remote, ssh_options);
         thread::spawn(move || actor.run());
 
         Self {

--- a/src/job_watcher.rs
+++ b/src/job_watcher.rs
@@ -11,16 +11,26 @@ struct JobWatcher {
     app: Sender<AppMessage>,
     interval: Duration,
     squeue_args: Vec<String>,
+    remote: Option<String>,
+    ssh_options: Option<String>,
 }
 
 pub struct JobWatcherHandle {}
 
 impl JobWatcher {
-    fn new(app: Sender<AppMessage>, interval: Duration, squeue_args: Vec<String>) -> Self {
+    fn new(
+        app: Sender<AppMessage>,
+        interval: Duration,
+        squeue_args: Vec<String>,
+        remote: Option<String>,
+        ssh_options: Option<String>,
+    ) -> Self {
         Self {
             app,
             interval,
             squeue_args,
+            remote,
+            ssh_options,
         }
     }
 
@@ -50,88 +60,122 @@ impl JobWatcher {
             .join(",");
 
         loop {
-            let jobs: Vec<Job> = Command::new("squeue")
-                .args(&self.squeue_args)
-                .arg("--array")
-                .arg("--noheader")
-                .arg("--Format")
-                .arg(&output_format)
-                .output()
-                .expect("failed to execute process")
-                .stdout
-                .lines()
-                .map(|l| l.unwrap().trim().to_string())
-                .filter_map(|l| {
-                    let parts: Vec<_> = l.split(output_separator).collect();
+            let mut command = if let Some(remote) = &self.remote {
+                let mut ssh_args = Vec::new();
+                if let Some(ssh_options) = &self.ssh_options {
+                    ssh_args.extend(ssh_options.split_whitespace().map(|s| s.to_string()));
+                }
+                ssh_args.push(remote.to_string());
+                ssh_args.push("squeue".to_string());
+                ssh_args.extend_from_slice(&self.squeue_args);
+                ssh_args.push("--array".to_string());
+                ssh_args.push("--noheader".to_string());
+                ssh_args.push("--Format".to_string());
+                ssh_args.push(output_format.clone());
+                let mut cmd = Command::new("ssh");
+                cmd.args(ssh_args);
+                cmd
+            } else {
+                let mut cmd = Command::new("squeue");
+                cmd.args(&self.squeue_args)
+                    .arg("--array")
+                    .arg("--noheader")
+                    .arg("--Format")
+                    .arg(&output_format);
+                cmd
+            };
 
-                    if parts.len() != fields.len() + 1 {
-                        return None;
+            let output = command.output();
+
+            match output {
+                Ok(output) => {
+                    if output.status.success() {
+                        let jobs: Vec<Job> = output
+                            .stdout
+                            .lines()
+                            .map(|l| l.unwrap().trim().to_string())
+                            .filter_map(|l| {
+                                let parts: Vec<_> = l.split(output_separator).collect();
+
+                                if parts.len() != fields.len() + 1 {
+                                    return None;
+                                }
+
+                                let id = parts[0];
+                                let name = parts[1];
+                                let state = parts[2];
+                                let user = parts[3];
+                                let time = parts[4];
+                                let tres = parts[5];
+                                let partition = parts[6];
+                                let nodelist = parts[7];
+                                let stdout = parts[8];
+                                let stderr = parts[9];
+                                let command = parts[10];
+                                let state_compact = parts[11];
+                                let reason = parts[12];
+
+                                let array_job_id = parts[13];
+                                let array_task_id = parts[14];
+                                let node_list = parts[15];
+                                let working_dir = parts[16];
+
+                                Some(Job {
+                                    job_id: id.to_owned(),
+                                    array_id: array_job_id.to_owned(),
+                                    array_step: match array_task_id {
+                                        "N/A" => None,
+                                        _ => Some(array_task_id.to_owned()),
+                                    },
+                                    name: name.to_owned(),
+                                    state: state.to_owned(),
+                                    state_compact: state_compact.to_owned(),
+                                    reason: if reason == "None" {
+                                        None
+                                    } else {
+                                        Some(reason.to_owned())
+                                    },
+                                    user: user.to_owned(),
+                                    time: time.to_owned(),
+                                    tres: tres.to_owned(),
+                                    partition: partition.to_owned(),
+                                    nodelist: nodelist.to_owned(),
+                                    command: command.to_owned(),
+                                    stdout: Self::resolve_path(
+                                        stdout,
+                                        array_job_id,
+                                        array_task_id,
+                                        id,
+                                        node_list,
+                                        user,
+                                        name,
+                                        working_dir,
+                                    ),
+                                    stderr: Self::resolve_path(
+                                        stderr,
+                                        array_job_id,
+                                        array_task_id,
+                                        id,
+                                        node_list,
+                                        user,
+                                        name,
+                                        working_dir,
+                                    ), // TODO fill all fields
+                                })
+                            })
+                            .collect();
+                        self.app.send(AppMessage::Jobs(jobs)).unwrap();
+                    } else {
+                        let err = String::from_utf8_lossy(&output.stderr).to_string();
+                        self.app.send(AppMessage::Error(err)).unwrap();
                     }
-
-                    let id = parts[0];
-                    let name = parts[1];
-                    let state = parts[2];
-                    let user = parts[3];
-                    let time = parts[4];
-                    let tres = parts[5];
-                    let partition = parts[6];
-                    let nodelist = parts[7];
-                    let stdout = parts[8];
-                    let stderr = parts[9];
-                    let command = parts[10];
-                    let state_compact = parts[11];
-                    let reason = parts[12];
-
-                    let array_job_id = parts[13];
-                    let array_task_id = parts[14];
-                    let node_list = parts[15];
-                    let working_dir = parts[16];
-
-                    Some(Job {
-                        job_id: id.to_owned(),
-                        array_id: array_job_id.to_owned(),
-                        array_step: match array_task_id {
-                            "N/A" => None,
-                            _ => Some(array_task_id.to_owned()),
-                        },
-                        name: name.to_owned(),
-                        state: state.to_owned(),
-                        state_compact: state_compact.to_owned(),
-                        reason: if reason == "None" {
-                            None
-                        } else {
-                            Some(reason.to_owned())
-                        },
-                        user: user.to_owned(),
-                        time: time.to_owned(),
-                        tres: tres.to_owned(),
-                        partition: partition.to_owned(),
-                        nodelist: nodelist.to_owned(),
-                        command: command.to_owned(),
-                        stdout: Self::resolve_path(
-                            stdout,
-                            array_job_id,
-                            array_task_id,
-                            id,
-                            node_list,
-                            user,
-                            name,
-                            working_dir,
-                        ),
-                        stderr: Self::resolve_path(
-                            stderr,
-                            array_job_id,
-                            array_task_id,
-                            id,
-                            node_list,
-                            user,
-                            name,
-                            working_dir,
-                        ), // TODO fill all fields
-                    })
-                })
-                .collect();
-            self.app.send(AppMessage::Jobs(jobs)).unwrap();
+                }
+                Err(err) => {
+                    self.app
+                        .send(AppMessage::Error(err.to_string()))
+                        .unwrap();
+                }
+            }
             thread::sleep(self.interval);
         }
     }
@@ -201,8 +245,14 @@ impl JobWatcher {
 }
 
 impl JobWatcherHandle {
-    pub fn new(app: Sender<AppMessage>, interval: Duration, squeue_args: Vec<String>) -> Self {
-        let mut actor = JobWatcher::new(app, interval, squeue_args);
+    pub fn new(
+        app: Sender<AppMessage>,
+        interval: Duration,
+        squeue_args: Vec<String>,
+        remote: Option<String>,
+        ssh_options: Option<String>,
+    ) -> Self {
+        let mut actor = JobWatcher::new(app, interval, squeue_args, remote, ssh_options);
         thread::spawn(move || actor.run());
 
         Self {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,14 @@ struct Cli {
     #[arg(long, value_name = "SECONDS", default_value_t = 2)]
     file_refresh: u64,
 
+    /// Run slurm commands on a remote host via ssh.
+    #[arg(long)]
+    remote: Option<String>,
+
+    /// Extra options to pass to the ssh command.
+    #[arg(long, value_name = "OPTIONS")]
+    ssh_options: Option<String>,
+
     /// squeue arguments
     #[command(flatten)]
     squeue_args: SqueueArgs,
@@ -93,6 +101,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, args: Cli) -> io::Result<()> 
         args.slurm_refresh,
         args.file_refresh,
         args.squeue_args.to_vec(),
+        args.remote,
+        args.ssh_options,
     );
     thread::spawn(move || input_loop(input_tx));
     app.run(terminal)


### PR DESCRIPTION
This PR adds the option to run `turm` through ssh, by running each slurm command call through ssh on a remote server, and is ideal for slurm clusters that are more restricted, where a user cannot easily install turm. Alternatively this is also convenient if you switch between multiple slurm clusters often. It also adds error logging within the ui if someting in `turm` breaks (instead of just showing nothing). I have tested the code with the args described in the new ssh section of the readme. The PR was written with the assistance of Google Gemini 2.5 Pro. I have manually reviewed the generated code, but my rust experience is currently fairly limited. Closes #43 

Below is an excerpt of the new readme section.

## Remote SSH

`turm` can be used to manage a remote Slurm cluster via SSH. This is useful when `turm` is not installed on the cluster, or when you want to manage multiple clusters from a single machine.

To use this feature, you need to specify the remote host using the `--remote` command-line option. For example:

```shell
turm --remote user@my-cluster
```

You can also specify additional SSH options using the `--ssh-options` command-line option. For example, to use a specific identity file, you can do:

```shell
turm --remote user@my-cluster --ssh-options "-i ~/.ssh/my-key"
```

When using the remote SSH feature, `turm` will execute all Slurm commands on the remote host. It will also read the job output files from the remote host.

**Note:** When using the remote SSH feature, it is recommended to set up SSH key-based authentication to avoid having to enter your password every time a command is executed.

