### PR TITLE
Feat/open log in pager

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -74,6 +74,7 @@ pub struct App {
     job_list_area: Rect,
     job_output_area: Rect,
     pending_input_event: Option<Event>,
+    pending_open_in_external: Option<PathBuf>,
 }
 
 pub struct Job {
@@ -166,6 +167,7 @@ impl App {
             job_list_area: Rect::default(),
             job_output_area: Rect::default(),
             pending_input_event: None,
+            pending_open_in_external: None,
         }
     }
 }
@@ -175,8 +177,7 @@ impl App {
         &mut self,
         terminal: &mut Terminal<B>,
         suspend: impl Fn() -> io::Result<()>,
-        resume: impl Fn() -> io::Result<()>,
-    ) -> io::Result<()> {
+        resume: impl Fn() -> io::Result<()>,) -> io::Result<()> {
         terminal.draw(|f| self.ui(f))?;
 
         loop {
@@ -197,7 +198,17 @@ impl App {
                 return Ok(());
             }
 
-            if should_draw {
+            if let Some(path) = self.pending_open_in_external.take() {
+                suspend()?;
+                let viewer_result = open_in_pager(&path);
+                resume()?;
+                while self.input_receiver.try_recv().is_ok() {}
+                terminal.clear()?;
+                if let Err(CommandFailure { command, output }) = viewer_result {
+                    self.dialog = Some(Dialog::CommandError { command, output });
+                }
+                terminal.draw(|f| self.ui(f))?;
+            } else if should_draw {
                 terminal.draw(|f| self.ui(f))?;
             }
         }
@@ -285,6 +296,15 @@ impl App {
             Some(MouseScrollTarget::Output)
         } else {
             None
+        }
+    }
+
+    fn current_log_path(&self) -> Option<PathBuf> {
+        let i = self.job_list_state.selected()?;
+        let job = self.jobs.get(i)?;
+        match self.output_file_view {
+            OutputFileView::Stdout => job.stdout.clone(),
+            OutputFileView::Stderr => job.stderr.clone(),
         }
     }
 
@@ -490,6 +510,17 @@ impl App {
                         KeyCode::Char('w') => {
                             self.job_output_wrap = !self.job_output_wrap;
                         }
+                        KeyCode::Char('O') => {
+                            if let Some(path) = self.current_log_path() {
+                                match std::fs::File::open(&path) {
+                                    Ok(_) => self.pending_open_in_external = Some(path),
+                                    Err(e) => self.dialog = Some(Dialog::CommandError {
+                                        command: path.to_string_lossy().into_owned(),
+                                        output: e.to_string(),
+                                    }),
+                                }
+                            }
+                        }
                         _ => {}
                     };
                 }
@@ -558,6 +589,7 @@ impl App {
             ("c/C", "cancel/signal"),
             ("t", "set time limit"),
             ("o", "toggle stdout/stderr"),
+            ("O", "open in $TURM_PAGER"),
             ("w", "toggle text wrap"),
         ];
         let blue_style = Style::default().fg(Color::Blue);
@@ -1202,6 +1234,27 @@ fn execute_command(mut command: Command, command_label: String) -> Result<(), Co
         command: command_label,
         output: details.join("\n\n"),
     })
+}
+
+fn open_in_pager(path: &Path) -> Result<(), CommandFailure> {
+    let pager = std::env::var("TURM_PAGER")
+        .unwrap_or_else(|_| "less".to_string());
+
+    let mut parts = pager.split_whitespace();
+    let program = parts.next().unwrap_or("less");
+    let args: Vec<&str> = parts.collect();
+
+    match Command::new(program).args(&args).arg(path).status() {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => Err(CommandFailure {
+            command: pager,
+            output: format!("Exited with {s}"),
+        }),
+        Err(e) => Err(CommandFailure {
+            command: pager,
+            output: e.to_string(),
+        }),
+    }
 }
 
 #[cfg(test)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,13 @@ use crossbeam::{
     select,
 };
 use itertools::Either;
-use std::{cmp::min, iter::once, path::PathBuf, process::Command, time::Duration};
+use std::{
+    cmp::min,
+    iter::once,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
 
 use crate::file_watcher::{FileWatcherError, FileWatcherHandle};
 use crate::job_watcher::JobWatcherHandle;
@@ -168,6 +174,8 @@ impl App {
     pub fn run<B: Backend<Error = io::Error>>(
         &mut self,
         terminal: &mut Terminal<B>,
+        suspend: impl Fn() -> io::Result<()>,
+        resume: impl Fn() -> io::Result<()>,
     ) -> io::Result<()> {
         terminal.draw(|f| self.ui(f))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,11 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
 };
 use squeue_args::SqueueArgs;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
 use std::{io, panic, thread};
 
 #[derive(Parser)]
@@ -124,18 +129,52 @@ impl Drop for TerminalGuard {
     }
 }
 
-fn input_loop(tx: Sender<std::io::Result<Event>>) {
-    while tx.send(event::read()).is_ok() {}
+fn input_loop(tx: Sender<std::io::Result<Event>>, suspended: Arc<AtomicBool>) {
+    loop {
+        if suspended.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_millis(50));
+            continue;
+        }
+        match event::poll(Duration::from_millis(50)) {
+            Ok(true) => {
+                if !suspended.load(Ordering::Relaxed) && tx.send(event::read()).is_err() {
+                    break;
+                }
+            }
+            Ok(false) => {}
+            Err(e) => {
+                if tx.send(Err(e)).is_err() {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 fn run_app<B: Backend<Error = io::Error>>(terminal: &mut Terminal<B>, args: Cli) -> io::Result<()> {
     let (input_tx, input_rx) = unbounded();
+    let suspended = Arc::new(AtomicBool::new(false));
+    let suspend = {
+        let suspended = suspended.clone();
+        move || -> io::Result<()> {
+            suspended.store(true, Ordering::SeqCst);
+            suspend_terminal()
+        }
+    };
+    let resume = {
+        let suspended = suspended.clone();
+        move || -> io::Result<()> {
+            let result = resume_terminal();
+            suspended.store(false, Ordering::SeqCst);
+            result
+        }
+    };
     let mut app = App::new(
         input_rx,
         args.slurm_refresh,
         args.file_refresh,
         args.squeue_args.to_vec(),
     );
-    thread::spawn(move || input_loop(input_tx));
-    app.run(terminal)
+    thread::spawn(move || input_loop(input_tx, suspended));
+    app.run(terminal, suspend, resume)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
 };
 use squeue_args::SqueueArgs;
-use std::io::Write;
 use std::{io, panic, thread};
 
 #[derive(Parser)]
@@ -67,58 +66,61 @@ fn main() -> io::Result<()> {
 
     install_panic_hook();
 
-    let mut terminal_guard = TerminalGuard::new(io::stdout())?;
+    let mut terminal_guard = TerminalGuard::new()?;
     run_app(terminal_guard.terminal_mut(), args)
+}
+
+fn suspend_terminal() -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(
+        io::stdout(),
+        LeaveAlternateScreen,
+        DisableBracketedPaste,
+        DisableMouseCapture,
+        Show
+    )?;
+    Ok(())
+}
+
+fn resume_terminal() -> io::Result<()> {
+    enable_raw_mode()?;
+    execute!(
+        io::stdout(),
+        EnterAlternateScreen,
+        EnableBracketedPaste,
+        EnableMouseCapture
+    )?;
+    Ok(())
 }
 
 fn install_panic_hook() {
     let default_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
-        let _ = disable_raw_mode();
-        let _ = execute!(
-            io::stdout(),
-            LeaveAlternateScreen,
-            DisableBracketedPaste,
-            DisableMouseCapture,
-            Show
-        );
+        let _ = suspend_terminal();
         default_hook(panic_info);
     }));
 }
 
-struct TerminalGuard<W: Write> {
-    terminal: Terminal<CrosstermBackend<W>>,
+struct TerminalGuard {
+    terminal: Terminal<CrosstermBackend<io::Stdout>>,
 }
 
-impl<W: Write> TerminalGuard<W> {
-    fn new(mut writer: W) -> io::Result<Self> {
-        enable_raw_mode()?;
-        execute!(
-            writer,
-            EnterAlternateScreen,
-            EnableBracketedPaste,
-            EnableMouseCapture
-        )?;
-        let backend = CrosstermBackend::new(writer);
+impl TerminalGuard {
+    fn new() -> io::Result<Self> {
+        resume_terminal()?;
+        let backend = CrosstermBackend::new(io::stdout());
         let terminal = Terminal::new(backend)?;
         Ok(Self { terminal })
     }
 
-    fn terminal_mut(&mut self) -> &mut Terminal<CrosstermBackend<W>> {
+    fn terminal_mut(&mut self) -> &mut Terminal<CrosstermBackend<io::Stdout>> {
         &mut self.terminal
     }
 }
 
-impl<W: Write> Drop for TerminalGuard<W> {
+impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        let _ = disable_raw_mode();
-        let _ = execute!(
-            self.terminal.backend_mut(),
-            LeaveAlternateScreen,
-            DisableBracketedPaste,
-            DisableMouseCapture
-        );
-        let _ = self.terminal.show_cursor();
+        let _ = suspend_terminal();
     }
 }
 


### PR DESCRIPTION
**Summary**
  
Pressing 'O' now opens the previewed log file in a pager ($TURM_PAGER, defaulting to less).

**Overview**

under the current implementation the input thread runs concurrently and would continue reading from the terminal while the pager is active, causing both to compete over the same input stream.
To handle this the input loop was changed from a blocking event::read() call to polling in 50ms bursts, and a shared atomic flag is used to pause it for the duration of the pager session. 
  
**Changes**

- Extracted suspend_terminal / resume_terminal helpers, consolidating duplicated terminal setup/teardown logic into a single abstraction used by startup, the panic hook, and exit.
- Rewrote the input loop to poll in 50ms bursts instead of blocking on event::read(), enabling it to respond to the suspended flag between polls.
- Added the O keybinding - opens whichever log file is currently shown (stdout or stderr) in $TURM_PAGER (defaults to less)