### PR TITLE
ci: replace archived actions-rs actions with maintained equivalents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,19 +64,17 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
+
+      - name: Setup | Cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Build | Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --locked --target ${{ matrix.target }}
-          use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+        run: cross build --release --locked --target ${{ matrix.target }}
 
       - name: Post Build | Prepare artifacts
         run: |


### PR DESCRIPTION
Replace `actions-rs/toolchain@v1` and `actions-rs/cargo@v1` (archived 2022, deprecated Node runtime) with `dtolnay/rust-toolchain@stable` for toolchain setup and `taiki-e/install-action@v2` + cross for cross-compilation.